### PR TITLE
오픈마켓 [STEP3] Joel

### DIFF
--- a/OpenMarket/OpenMarket.xcodeproj/project.pbxproj
+++ b/OpenMarket/OpenMarket.xcodeproj/project.pbxproj
@@ -24,6 +24,7 @@
 		6E10223927ABE13300359BD0 /* ListProductStackView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6E10223827ABE13300359BD0 /* ListProductStackView.swift */; };
 		6E307D5F27B01A0E006ABA91 /* ProductListSegmentValue.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6E307D5E27B01A0E006ABA91 /* ProductListSegmentValue.swift */; };
 		6E307D6727B26B6A006ABA91 /* ProductCellViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6E307D6627B26B6A006ABA91 /* ProductCellViewModel.swift */; };
+		6E307D6927B3B613006ABA91 /* ProductPriceSegmentValue.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6E307D6827B3B613006ABA91 /* ProductPriceSegmentValue.swift */; };
 		6EDC38D9279E9389000BC3D9 /* Constant.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6EDC38D8279E9389000BC3D9 /* Constant.swift */; };
 		6EDC38DD279EBAC2000BC3D9 /* RepositoryInjection.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6EDC38DC279EBAC2000BC3D9 /* RepositoryInjection.swift */; };
 		6EDC38E2279EBBC7000BC3D9 /* Product.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6EDC38E1279EBBC7000BC3D9 /* Product.swift */; };
@@ -74,6 +75,7 @@
 		6E10223827ABE13300359BD0 /* ListProductStackView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ListProductStackView.swift; sourceTree = "<group>"; };
 		6E307D5E27B01A0E006ABA91 /* ProductListSegmentValue.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProductListSegmentValue.swift; sourceTree = "<group>"; };
 		6E307D6627B26B6A006ABA91 /* ProductCellViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProductCellViewModel.swift; sourceTree = "<group>"; };
+		6E307D6827B3B613006ABA91 /* ProductPriceSegmentValue.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProductPriceSegmentValue.swift; sourceTree = "<group>"; };
 		6EDC38D8279E9389000BC3D9 /* Constant.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Constant.swift; sourceTree = "<group>"; };
 		6EDC38DC279EBAC2000BC3D9 /* RepositoryInjection.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RepositoryInjection.swift; sourceTree = "<group>"; };
 		6EDC38E1279EBBC7000BC3D9 /* Product.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Product.swift; sourceTree = "<group>"; };
@@ -167,6 +169,7 @@
 			isa = PBXGroup;
 			children = (
 				6E10220C27AA34F300359BD0 /* ProductViewController.swift */,
+				6E307D6827B3B613006ABA91 /* ProductPriceSegmentValue.swift */,
 			);
 			path = ProductView;
 			sourceTree = "<group>";
@@ -411,6 +414,7 @@
 				C70FB0FB25BEF61C00C9924E /* AppDelegate.swift in Sources */,
 				6E10222727AA8A1B00359BD0 /* ProductCell.swift in Sources */,
 				6E10223027ABDB6300359BD0 /* BaseStackView.swift in Sources */,
+				6E307D6927B3B613006ABA91 /* ProductPriceSegmentValue.swift in Sources */,
 				6E10222B27ABA60700359BD0 /* GridCollectionViewCell.swift in Sources */,
 				6EDC38E4279EC006000BC3D9 /* ProductList.swift in Sources */,
 				6E10223527ABE10F00359BD0 /* ListPriceStackView.swift in Sources */,

--- a/OpenMarket/OpenMarket.xcodeproj/project.pbxproj
+++ b/OpenMarket/OpenMarket.xcodeproj/project.pbxproj
@@ -12,7 +12,7 @@
 		6E1021DB27A024FA00359BD0 /* ProductRepository.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6E1021DA27A024FA00359BD0 /* ProductRepository.swift */; };
 		6E1021DD27A0254200359BD0 /* ProductListRepositoryImpl.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6E1021DC27A0254200359BD0 /* ProductListRepositoryImpl.swift */; };
 		6E1021DF27A0254E00359BD0 /* ProductRepositoryImpl.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6E1021DE27A0254E00359BD0 /* ProductRepositoryImpl.swift */; };
-		6E10220D27AA34F300359BD0 /* ProductViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6E10220C27AA34F300359BD0 /* ProductViewController.swift */; };
+		6E10220D27AA34F300359BD0 /* ProductEditViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6E10220C27AA34F300359BD0 /* ProductEditViewController.swift */; };
 		6E10222427AA85E700359BD0 /* ListCollectionViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6E10222227AA85E700359BD0 /* ListCollectionViewCell.swift */; };
 		6E10222727AA8A1B00359BD0 /* ProductCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6E10222627AA8A1B00359BD0 /* ProductCell.swift */; };
 		6E10222B27ABA60700359BD0 /* GridCollectionViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6E10222A27ABA60700359BD0 /* GridCollectionViewCell.swift */; };
@@ -26,6 +26,7 @@
 		6E307D6727B26B6A006ABA91 /* ProductCellViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6E307D6627B26B6A006ABA91 /* ProductCellViewModel.swift */; };
 		6E307D6927B3B613006ABA91 /* ProductPriceSegmentValue.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6E307D6827B3B613006ABA91 /* ProductPriceSegmentValue.swift */; };
 		6E307D6B27B402F2006ABA91 /* PostProduct.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6E307D6A27B402F2006ABA91 /* PostProduct.swift */; };
+		6EA854D327B519FD0043524F /* ProductDeatilViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6EA854D227B519FD0043524F /* ProductDeatilViewController.swift */; };
 		6EDC38D9279E9389000BC3D9 /* Constant.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6EDC38D8279E9389000BC3D9 /* Constant.swift */; };
 		6EDC38DD279EBAC2000BC3D9 /* RepositoryInjection.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6EDC38DC279EBAC2000BC3D9 /* RepositoryInjection.swift */; };
 		6EDC38E2279EBBC7000BC3D9 /* Product.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6EDC38E1279EBBC7000BC3D9 /* Product.swift */; };
@@ -64,7 +65,7 @@
 		6E1021DA27A024FA00359BD0 /* ProductRepository.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProductRepository.swift; sourceTree = "<group>"; };
 		6E1021DC27A0254200359BD0 /* ProductListRepositoryImpl.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProductListRepositoryImpl.swift; sourceTree = "<group>"; };
 		6E1021DE27A0254E00359BD0 /* ProductRepositoryImpl.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProductRepositoryImpl.swift; sourceTree = "<group>"; };
-		6E10220C27AA34F300359BD0 /* ProductViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProductViewController.swift; sourceTree = "<group>"; };
+		6E10220C27AA34F300359BD0 /* ProductEditViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProductEditViewController.swift; sourceTree = "<group>"; };
 		6E10222227AA85E700359BD0 /* ListCollectionViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ListCollectionViewCell.swift; sourceTree = "<group>"; };
 		6E10222627AA8A1B00359BD0 /* ProductCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProductCell.swift; sourceTree = "<group>"; };
 		6E10222A27ABA60700359BD0 /* GridCollectionViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GridCollectionViewCell.swift; sourceTree = "<group>"; };
@@ -78,6 +79,7 @@
 		6E307D6627B26B6A006ABA91 /* ProductCellViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProductCellViewModel.swift; sourceTree = "<group>"; };
 		6E307D6827B3B613006ABA91 /* ProductPriceSegmentValue.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProductPriceSegmentValue.swift; sourceTree = "<group>"; };
 		6E307D6A27B402F2006ABA91 /* PostProduct.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PostProduct.swift; sourceTree = "<group>"; };
+		6EA854D227B519FD0043524F /* ProductDeatilViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProductDeatilViewController.swift; sourceTree = "<group>"; };
 		6EDC38D8279E9389000BC3D9 /* Constant.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Constant.swift; sourceTree = "<group>"; };
 		6EDC38DC279EBAC2000BC3D9 /* RepositoryInjection.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RepositoryInjection.swift; sourceTree = "<group>"; };
 		6EDC38E1279EBBC7000BC3D9 /* Product.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Product.swift; sourceTree = "<group>"; };
@@ -170,7 +172,8 @@
 		6E307D6127B0C245006ABA91 /* ProductView */ = {
 			isa = PBXGroup;
 			children = (
-				6E10220C27AA34F300359BD0 /* ProductViewController.swift */,
+				6EA854D227B519FD0043524F /* ProductDeatilViewController.swift */,
+				6E10220C27AA34F300359BD0 /* ProductEditViewController.swift */,
 				6E307D6827B3B613006ABA91 /* ProductPriceSegmentValue.swift */,
 			);
 			path = ProductView;
@@ -407,7 +410,7 @@
 				6E307D6727B26B6A006ABA91 /* ProductCellViewModel.swift in Sources */,
 				6E1021D927A024CF00359BD0 /* ProductListRepository.swift in Sources */,
 				6EDC38F8279F9021000BC3D9 /* NetworkError.swift in Sources */,
-				6E10220D27AA34F300359BD0 /* ProductViewController.swift in Sources */,
+				6E10220D27AA34F300359BD0 /* ProductEditViewController.swift in Sources */,
 				6E1021DD27A0254200359BD0 /* ProductListRepositoryImpl.swift in Sources */,
 				6EDC38E8279EC0A4000BC3D9 /* ProductListViewModel.swift in Sources */,
 				C70FB0FF25BEF61C00C9924E /* ProductListViewController.swift in Sources */,
@@ -433,6 +436,7 @@
 				6EDC38E6279EC021000BC3D9 /* ProductImage.swift in Sources */,
 				6EDC38EC279EC50D000BC3D9 /* Vendor.swift in Sources */,
 				6EDC38D9279E9389000BC3D9 /* Constant.swift in Sources */,
+				6EA854D327B519FD0043524F /* ProductDeatilViewController.swift in Sources */,
 				6EDC38EA279EC0B0000BC3D9 /* ProductViewModel.swift in Sources */,
 				6E10223927ABE13300359BD0 /* ListProductStackView.swift in Sources */,
 				6E307D6B27B402F2006ABA91 /* PostProduct.swift in Sources */,

--- a/OpenMarket/OpenMarket.xcodeproj/project.pbxproj
+++ b/OpenMarket/OpenMarket.xcodeproj/project.pbxproj
@@ -25,6 +25,7 @@
 		6E307D5F27B01A0E006ABA91 /* ProductListSegmentValue.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6E307D5E27B01A0E006ABA91 /* ProductListSegmentValue.swift */; };
 		6E307D6727B26B6A006ABA91 /* ProductCellViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6E307D6627B26B6A006ABA91 /* ProductCellViewModel.swift */; };
 		6E307D6927B3B613006ABA91 /* ProductPriceSegmentValue.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6E307D6827B3B613006ABA91 /* ProductPriceSegmentValue.swift */; };
+		6E307D6B27B402F2006ABA91 /* PostProduct.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6E307D6A27B402F2006ABA91 /* PostProduct.swift */; };
 		6EDC38D9279E9389000BC3D9 /* Constant.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6EDC38D8279E9389000BC3D9 /* Constant.swift */; };
 		6EDC38DD279EBAC2000BC3D9 /* RepositoryInjection.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6EDC38DC279EBAC2000BC3D9 /* RepositoryInjection.swift */; };
 		6EDC38E2279EBBC7000BC3D9 /* Product.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6EDC38E1279EBBC7000BC3D9 /* Product.swift */; };
@@ -76,6 +77,7 @@
 		6E307D5E27B01A0E006ABA91 /* ProductListSegmentValue.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProductListSegmentValue.swift; sourceTree = "<group>"; };
 		6E307D6627B26B6A006ABA91 /* ProductCellViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProductCellViewModel.swift; sourceTree = "<group>"; };
 		6E307D6827B3B613006ABA91 /* ProductPriceSegmentValue.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProductPriceSegmentValue.swift; sourceTree = "<group>"; };
+		6E307D6A27B402F2006ABA91 /* PostProduct.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PostProduct.swift; sourceTree = "<group>"; };
 		6EDC38D8279E9389000BC3D9 /* Constant.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Constant.swift; sourceTree = "<group>"; };
 		6EDC38DC279EBAC2000BC3D9 /* RepositoryInjection.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RepositoryInjection.swift; sourceTree = "<group>"; };
 		6EDC38E1279EBBC7000BC3D9 /* Product.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Product.swift; sourceTree = "<group>"; };
@@ -233,6 +235,7 @@
 				6EDC38E3279EC006000BC3D9 /* ProductList.swift */,
 				6EDC38E5279EC021000BC3D9 /* ProductImage.swift */,
 				6EDC38EB279EC50D000BC3D9 /* Vendor.swift */,
+				6E307D6A27B402F2006ABA91 /* PostProduct.swift */,
 			);
 			path = Product;
 			sourceTree = "<group>";
@@ -432,6 +435,7 @@
 				6EDC38D9279E9389000BC3D9 /* Constant.swift in Sources */,
 				6EDC38EA279EC0B0000BC3D9 /* ProductViewModel.swift in Sources */,
 				6E10223927ABE13300359BD0 /* ListProductStackView.swift in Sources */,
+				6E307D6B27B402F2006ABA91 /* PostProduct.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/OpenMarket/OpenMarket/Common/Constant.swift
+++ b/OpenMarket/OpenMarket/Common/Constant.swift
@@ -7,6 +7,7 @@
 
 struct Constant {
     static let productAddSegue = "moveProductAddIdentifier"
+    static let productDetailSegue = "moveProductDetailIdentifier"
     static let productEditSegue = "moveProductEditIdentifier"
     static let soldOutText = "품절"
     static let remainingQuantityText = "잔여수량"

--- a/OpenMarket/OpenMarket/Common/Constant.swift
+++ b/OpenMarket/OpenMarket/Common/Constant.swift
@@ -6,8 +6,14 @@
 //
 
 struct Constant {
-    static let productSegue = "moveProductIdentifier"
+    static let productAddSegue = "moveProductAddIdentifier"
+    static let productEditSegue = "moveProductEditIdentifier"
     static let soldOutText = "품절"
     static let remainingQuantityText = "잔여수량"
     static let itemsPerPage = 30
+    static let productNameTextFieldPlaceholder = "상품명"
+    static let productOriginPriceTextFieldPlaceholder = "상품가격"
+    static let productDiscountedPriceTextFieldPlaceholder = "할인가격"
+    static let productStockTextFieldPlaceholder = "재고수량"
+    static let productDescriptionTextViewPlaceholder = "상품에 대해 설명해주세요."
 }

--- a/OpenMarket/OpenMarket/Common/Constant.swift
+++ b/OpenMarket/OpenMarket/Common/Constant.swift
@@ -16,4 +16,6 @@ struct Constant {
     static let productDiscountedPriceTextFieldPlaceholder = "할인가격"
     static let productStockTextFieldPlaceholder = "재고수량"
     static let productDescriptionTextViewPlaceholder = "상품에 대해 설명해주세요."
+    static let identifier = "a16de1ff-7217-11ec-abfa-d7e4ab0f3a0b"
+    static let secret = "_8rLkXbV2s47Z4Xz"
 }

--- a/OpenMarket/OpenMarket/Models/Networking/JSONConverter.swift
+++ b/OpenMarket/OpenMarket/Models/Networking/JSONConverter.swift
@@ -20,4 +20,14 @@ struct JSONConverter {
             return nil
         }
     }
+
+    static func encode<T: Codable>(_ model: T) -> Data? {
+        let encoder: JSONEncoder = JSONEncoder()
+         do {
+             let response = try encoder.encode(model)
+             return response
+         } catch {
+             return nil
+         }
+     }
 }

--- a/OpenMarket/OpenMarket/Models/Networking/NetworkManager.swift
+++ b/OpenMarket/OpenMarket/Models/Networking/NetworkManager.swift
@@ -38,6 +38,19 @@ struct NetworkManager {
         self.sessionDataTastRequest(request: request, completion: completion)
     }
 
+    func patch<T: Decodable>(url: URL, postProduct: PostProduct, productImages: [UIImage?], completion: @escaping (Result<T?, NetworkError>) -> Void) {
+        var request = URLRequest(url: url)
+        request.httpMethod = HTTPMethod.patch.description
+
+        // Header
+        request.setValue(Constant.identifier, forHTTPHeaderField: "identifier")
+
+        // Body
+        request.httpBody = JSONConverter.encode(postProduct)
+
+        self.sessionDataTastRequest(request: request, completion: completion)
+    }
+
     @discardableResult 
     private func createBody(boundary: String, postProduct: PostProduct, productImages: [UIImage?]) -> Data? {
         guard let boundaryPrefix = "--\(boundary)\r\n".data(using: .utf8),

--- a/OpenMarket/OpenMarket/Models/Networking/NetworkManager.swift
+++ b/OpenMarket/OpenMarket/Models/Networking/NetworkManager.swift
@@ -6,6 +6,7 @@
 //
 
 import Foundation
+import UIKit
 
 struct NetworkManager {
 
@@ -15,7 +16,78 @@ struct NetworkManager {
         var request = URLRequest(url: url)
         request.httpMethod = HTTPMethod.get.description
 
-        session.dataTask(with: request) { data, response, error in
+        self.sessionDataTastRequest(request: request, completion: completion)
+    }
+
+    func post<T: Decodable>(url: URL, postProduct: PostProduct, productImages: [UIImage?], completion: @escaping (Result<T?, NetworkError>) -> Void) {
+        let boundary = "Boundary-\(UUID().uuidString)"
+        var request = URLRequest(url: url)
+        request.httpMethod = HTTPMethod.post.description
+
+        // Header
+        request.setValue(Constant.identifier, forHTTPHeaderField: "identifier")
+        request.setValue("multipart/form-data; boundary=\(boundary)", forHTTPHeaderField: "Content-Type")
+
+        // Body
+        request.httpBody = self.createBody(
+            boundary: boundary,
+            postProduct: postProduct,
+            productImages: productImages
+        )
+
+        self.sessionDataTastRequest(request: request, completion: completion)
+    }
+
+    @discardableResult 
+    private func createBody(boundary: String, postProduct: PostProduct, productImages: [UIImage?]) -> Data? {
+        guard let boundaryPrefix = "--\(boundary)\r\n".data(using: .utf8),
+            let boundaryPostfix = "--\(boundary)--\r\n".data(using: .utf8),
+            let lineAlignment = "\r\n".data(using: .utf8),
+            let paramsContentDisposition = "Content-Disposition: form-data; name=params\r\n".data(using: .utf8),
+            let paramsContentType = "Content-Type: application/json\r\n\r\n".data(using: .utf8),
+            let postProductJson = JSONConverter.encode(postProduct),
+            let imagesContentDisposition = "Content-Disposition: form-data; name=images; filename=image.jpeg\r\n".data(using: .utf8),
+            let imagesContentType = "Content-Type: image/jpeg\r\n\r\n".data(using: .utf8)
+        else {
+            return nil
+        }
+
+        var body = Data()
+        body.append(boundaryPrefix)
+
+        body.append(paramsContentDisposition)
+        body.append(paramsContentType)
+        body.append(postProductJson)
+        body.append(lineAlignment)
+
+        let imageDatas = productImages
+            .compactMap {
+                $0?.jpegData(compressionQuality: 0.1)
+            }
+        imageDatas.map {
+            body.append(boundaryPrefix)
+            body.append(imagesContentDisposition)
+            body.append(imagesContentType)
+            body.append($0)
+            body.append(lineAlignment)
+        }
+
+        body.append(boundaryPostfix)
+        return body
+    }
+
+    func image(url: URL, completion: @escaping (Data) -> Void) {
+        session.dataTask(with: url) { data, _, _ in
+            guard let data = data else {
+                return
+            }
+
+            completion(data)
+        }.resume()
+    }
+
+    private func sessionDataTastRequest<T: Decodable>(request: URLRequest, completion: @escaping (Result<T?, NetworkError>) -> Void) {
+        self.session.dataTask(with: request) { data, response, error in
             guard error == nil else {
                 completion(.failure(.transportError))
                 return
@@ -25,7 +97,7 @@ struct NetworkManager {
                 completion(.failure(.responseError))
                 return
             }
-            
+
             guard (200...299).contains(response.statusCode) else {
                 completion(.failure(.networkFailure(statusCode: response.statusCode)))
                 return
@@ -42,16 +114,6 @@ struct NetworkManager {
             }
 
             completion(.success(decodedData))
-        }.resume()
-    }
-
-    func image(url: URL, completion: @escaping (Data) -> Void) {
-        session.dataTask(with: url) { data, _, _ in
-            guard let data = data else {
-                return
-            }
-
-            completion(data)
         }.resume()
     }
 }

--- a/OpenMarket/OpenMarket/Models/Networking/OpenMarketURL.swift
+++ b/OpenMarket/OpenMarket/Models/Networking/OpenMarketURL.swift
@@ -12,6 +12,7 @@ enum OpenMarketURL {
     case productList(pageNumber: Int, itemsPerPage: Int)
     case product(productId: Int)
     case addProduct
+    case updateProduct(productId: Int)
 
     var url: URL? {
         switch self {
@@ -21,6 +22,8 @@ enum OpenMarketURL {
             return URL(string: "\(OpenMarketURL.baseURL)/api/products/\(productId)")
         case .addProduct:
             return URL(string: "\(OpenMarketURL.baseURL)/api/products")
+        case .updateProduct(let productId):
+            return URL(string: "\(OpenMarketURL.baseURL)/api/products/\(productId)")
         }
     }
 }

--- a/OpenMarket/OpenMarket/Models/Networking/OpenMarketURL.swift
+++ b/OpenMarket/OpenMarket/Models/Networking/OpenMarketURL.swift
@@ -11,6 +11,7 @@ enum OpenMarketURL {
     static let baseURL = "https://market-training.yagom-academy.kr/"
     case productList(pageNumber: Int, itemsPerPage: Int)
     case product(productId: Int)
+    case addProduct
 
     var url: URL? {
         switch self {
@@ -18,6 +19,8 @@ enum OpenMarketURL {
             return URL(string: "\(OpenMarketURL.baseURL)/api/products?page_no=\(pageNumber)&items_per_page=\(itemsPerPage)")
         case .product(let productId):
             return URL(string: "\(OpenMarketURL.baseURL)/api/products/\(productId)")
+        case .addProduct:
+            return URL(string: "\(OpenMarketURL.baseURL)/api/products")
         }
     }
 }

--- a/OpenMarket/OpenMarket/Models/Product/PostProduct.swift
+++ b/OpenMarket/OpenMarket/Models/Product/PostProduct.swift
@@ -1,0 +1,21 @@
+//
+//  PostProduct.swift
+//  OpenMarket
+//
+//  Created by 이승주 on 2022/02/09.
+//
+
+struct PostProduct: Codable {
+    let name: String
+    let descriptions: String
+    let price: Double
+    let currency: String
+    let discountedPrice: Double
+    let stock: Int
+    let secret: String
+
+    enum CodingKeys: String, CodingKey {
+        case discountedPrice = "discounted_price"
+        case name, descriptions, currency, price, stock, secret
+    }
+}

--- a/OpenMarket/OpenMarket/Models/Repository/ProductListRepository.swift
+++ b/OpenMarket/OpenMarket/Models/Repository/ProductListRepository.swift
@@ -9,5 +9,4 @@ import UIKit
 
 protocol ProductListRepository {
     func productList(pageNumber: Int, itemsPerPage: Int , completion: @escaping (Result<ProductList?, NetworkError>) -> Void)
-    func image(url: URL, completion: @escaping (Data) -> Void)
 }

--- a/OpenMarket/OpenMarket/Models/Repository/ProductListRepositoryImpl.swift
+++ b/OpenMarket/OpenMarket/Models/Repository/ProductListRepositoryImpl.swift
@@ -19,8 +19,4 @@ struct ProductListRepositoryImpl: ProductListRepository {
 
         self.networkManager.get(url: url, completion: completion)
     }
-
-    func image(url: URL, completion: @escaping (Data) -> Void) {
-        self.networkManager.image(url: url, completion: completion)
-    }
 }

--- a/OpenMarket/OpenMarket/Models/Repository/ProductRepository.swift
+++ b/OpenMarket/OpenMarket/Models/Repository/ProductRepository.swift
@@ -5,10 +5,12 @@
 //  Created by 이승주 on 2022/01/25.
 //
 
+import UIKit
+
 protocol ProductRepository {
     func product(productId: Int, completion: @escaping (Result<Product?, NetworkError>) -> Void)
     func productSecret()
-    func addProduct()
+    func addProduct(postProduct: PostProduct, productImages: [UIImage?], completion: @escaping (Result<Product?, NetworkError>) -> Void)
     func updateProduct()
     func deleteProduct()
 }

--- a/OpenMarket/OpenMarket/Models/Repository/ProductRepository.swift
+++ b/OpenMarket/OpenMarket/Models/Repository/ProductRepository.swift
@@ -11,6 +11,7 @@ protocol ProductRepository {
     func product(productId: Int, completion: @escaping (Result<Product?, NetworkError>) -> Void)
     func productSecret()
     func addProduct(postProduct: PostProduct, productImages: [UIImage?], completion: @escaping (Result<Product?, NetworkError>) -> Void)
-    func updateProduct()
+    func updateProduct(productId: Int, postProduct: PostProduct, productImages: [UIImage?], completion: @escaping (Result<Product?, NetworkError>) -> Void)
     func deleteProduct()
+    func image(url: URL, completion: @escaping (Data) -> Void)
 }

--- a/OpenMarket/OpenMarket/Models/Repository/ProductRepositoryImpl.swift
+++ b/OpenMarket/OpenMarket/Models/Repository/ProductRepositoryImpl.swift
@@ -33,11 +33,20 @@ struct ProductRepositoryImpl: ProductRepository {
         self.networkManager.post(url: url, postProduct: postProduct, productImages: productImages, completion: completion)
     }
 
-    func updateProduct() {
+    func updateProduct(productId: Int, postProduct: PostProduct, productImages: [UIImage?], completion: @escaping (Result<Product?, NetworkError>) -> Void) {
+        guard let url = OpenMarketURL.updateProduct(productId: productId).url else {
+            completion(.failure(.invalidURL))
+            return
+        }
 
+        self.networkManager.patch(url: url, postProduct: postProduct, productImages: productImages, completion: completion)
     }
 
     func deleteProduct() {
         
+    }
+
+    func image(url: URL, completion: @escaping (Data) -> Void) {
+        self.networkManager.image(url: url, completion: completion)
     }
 }

--- a/OpenMarket/OpenMarket/Models/Repository/ProductRepositoryImpl.swift
+++ b/OpenMarket/OpenMarket/Models/Repository/ProductRepositoryImpl.swift
@@ -5,6 +5,8 @@
 //  Created by 이승주 on 2022/01/25.
 //
 
+import UIKit
+
 struct ProductRepositoryImpl: ProductRepository {
 
     private let networkManager = NetworkManager()
@@ -22,8 +24,13 @@ struct ProductRepositoryImpl: ProductRepository {
 
     }
 
-    func addProduct() {
+    func addProduct(postProduct: PostProduct, productImages: [UIImage?], completion: @escaping (Result<Product?, NetworkError>) -> Void) {
+        guard let url = OpenMarketURL.addProduct.url else {
+            completion(.failure(.invalidURL))
+            return
+        }
 
+        self.networkManager.post(url: url, postProduct: postProduct, productImages: productImages, completion: completion)
     }
 
     func updateProduct() {

--- a/OpenMarket/OpenMarket/ViewModels/ProductCellViewModel.swift
+++ b/OpenMarket/OpenMarket/ViewModels/ProductCellViewModel.swift
@@ -8,7 +8,7 @@
 import UIKit
 
 class ProductCellViewModel {
-    private let repository: ProductListRepository = RepositoryInjection.injectProductListRepository()
+    private let repository: ProductRepository = RepositoryInjection.injectProductRepository()
     private let imageCache = NSCache<NSString, UIImage>()
     var updateImage: () -> Void = {}
 

--- a/OpenMarket/OpenMarket/ViewModels/ProductListViewModel.swift
+++ b/OpenMarket/OpenMarket/ViewModels/ProductListViewModel.swift
@@ -39,4 +39,9 @@ class ProductListViewModel {
             }
         }
     }
+
+    func productListReset() {
+        self.products = []
+        self.pageNumber = 0
+    }
 }

--- a/OpenMarket/OpenMarket/ViewModels/ProductViewModel.swift
+++ b/OpenMarket/OpenMarket/ViewModels/ProductViewModel.swift
@@ -5,9 +5,12 @@
 //  Created by 이승주 on 2022/01/24.
 //
 
+import UIKit
+
 class ProductViewModel {
     private let repository: ProductRepository = RepositoryInjection.injectProductRepository()
     var updateView: () -> Void = {}
+    var addedProduct: () -> Void = {}
 
     var product: Product? {
         didSet {
@@ -15,12 +18,36 @@ class ProductViewModel {
         }
     }
 
+    var successPostProduct: Bool? {
+        willSet {
+            if newValue == true {
+                self.addedProduct()
+            }
+        }
+    }
+
     func product(productId: Int) {
-        self.repository.product(productId: productId) { result in
+        self.repository.product(productId: productId) { [weak self] result in
+            guard let self = self else { return }
+
             switch result {
             case .success(let product):
                 self.product = product
             case .failure(let error):
+                print(error.errorDescription)
+            }
+        }
+    }
+
+    func addProduct(postProduct: PostProduct, productImages: [UIImage?]) {
+        self.repository.addProduct(postProduct: postProduct, productImages: productImages) { [weak self] result in
+            guard let self = self else { return }
+
+            switch result {
+            case .success(let product):
+                self.successPostProduct = true
+            case .failure(let error):
+                self.successPostProduct = false
                 print(error.errorDescription)
             }
         }

--- a/OpenMarket/OpenMarket/ViewModels/ProductViewModel.swift
+++ b/OpenMarket/OpenMarket/ViewModels/ProductViewModel.swift
@@ -11,6 +11,13 @@ class ProductViewModel {
     private let repository: ProductRepository = RepositoryInjection.injectProductRepository()
     var updateView: () -> Void = {}
     var addedProduct: () -> Void = {}
+    var updateImage: () -> Void = {}
+
+    var productImage: UIImage? {
+        didSet {
+            self.updateImage()
+        }
+    }
 
     var product: Product? {
         didSet {
@@ -26,7 +33,9 @@ class ProductViewModel {
         }
     }
 
-    func product(productId: Int) {
+    func product(productId: Int?) {
+        guard let productId = productId else { return }
+
         self.repository.product(productId: productId) { [weak self] result in
             guard let self = self else { return }
 
@@ -49,6 +58,36 @@ class ProductViewModel {
             case .failure(let error):
                 self.successPostProduct = false
                 print(error.errorDescription)
+            }
+        }
+    }
+
+    func updateProduct(productId: Int, postProduct: PostProduct, productImages: [UIImage?]) {
+        self.repository.updateProduct(productId: productId, postProduct: postProduct, productImages: productImages) { [weak self] result in
+            guard let self = self else { return }
+
+            switch result {
+            case .success(let product):
+                self.successPostProduct = true
+            case .failure(let error):
+                self.successPostProduct = false
+                print(error.errorDescription)
+            }
+        }
+    }
+
+    func productImage(url: String) {
+        guard let url = URL(string: url) else { return }
+
+        self.repository.image(url: url) { [weak self] data in
+            guard let self = self,
+              let productImage = UIImage(data: data)
+            else {
+                return
+            }
+
+            DispatchQueue.main.async {
+                self.productImage = productImage
             }
         }
     }

--- a/OpenMarket/OpenMarket/Views/Main.storyboard
+++ b/OpenMarket/OpenMarket/Views/Main.storyboard
@@ -82,17 +82,17 @@
                         <outlet property="pagingLoadingUI" destination="K13-zX-OTx" id="tgc-aS-5WF"/>
                         <outlet property="productListCollectionView" destination="R7k-BP-r2b" id="wbl-gX-w3j"/>
                         <outlet property="productSegmentedControl" destination="pIz-nS-wBh" id="DWY-NM-H81"/>
-                        <segue destination="kQk-vz-ntW" kind="show" identifier="moveProductEditIdentifier" id="n3Z-5a-a4F"/>
+                        <segue destination="pja-ox-qZI" kind="show" identifier="moveProductDetailIdentifier" id="Yx0-bj-Gdf"/>
                     </connections>
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="jpN-rM-LsM" userLabel="First Responder" customClass="UIResponder" sceneMemberID="firstResponder"/>
             </objects>
             <point key="canvasLocation" x="-197" y="265"/>
         </scene>
-        <!--Product View Controller-->
+        <!--Product Edit View Controller-->
         <scene sceneID="bow-Ka-ntq">
             <objects>
-                <viewController id="kQk-vz-ntW" customClass="ProductViewController" customModule="OpenMarket" customModuleProvider="target" sceneMemberID="viewController">
+                <viewController id="kQk-vz-ntW" customClass="ProductEditViewController" customModule="OpenMarket" customModuleProvider="target" sceneMemberID="viewController">
                     <view key="view" contentMode="scaleToFill" id="zFo-2Y-hlu">
                         <rect key="frame" x="0.0" y="0.0" width="414" height="896"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
@@ -103,7 +103,26 @@
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="zEo-Pc-Gws" userLabel="First Responder" customClass="UIResponder" sceneMemberID="firstResponder"/>
             </objects>
-            <point key="canvasLocation" x="526" y="265"/>
+            <point key="canvasLocation" x="1680" y="265"/>
+        </scene>
+        <!--Product Deatil View Controller-->
+        <scene sceneID="fEV-C5-vfD">
+            <objects>
+                <viewController id="pja-ox-qZI" customClass="ProductDeatilViewController" customModule="OpenMarket" customModuleProvider="target" sceneMemberID="viewController">
+                    <view key="view" contentMode="scaleToFill" id="TCB-eS-oc6">
+                        <rect key="frame" x="0.0" y="0.0" width="414" height="896"/>
+                        <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                        <viewLayoutGuide key="safeArea" id="BwB-kG-jiD"/>
+                        <color key="backgroundColor" systemColor="systemBackgroundColor"/>
+                    </view>
+                    <navigationItem key="navigationItem" id="nIj-Kl-DE5"/>
+                    <connections>
+                        <segue destination="kQk-vz-ntW" kind="show" identifier="moveProductEditIdentifier" id="eRb-MF-2ki"/>
+                    </connections>
+                </viewController>
+                <placeholder placeholderIdentifier="IBFirstResponder" id="Bri-y6-AU7" userLabel="First Responder" customClass="UIResponder" sceneMemberID="firstResponder"/>
+            </objects>
+            <point key="canvasLocation" x="733" y="612"/>
         </scene>
         <!--Navigation Controller-->
         <scene sceneID="lwC-fa-mnN">
@@ -123,7 +142,7 @@
         </scene>
     </scenes>
     <inferredMetricsTieBreakers>
-        <segue reference="7qH-ul-JML"/>
+        <segue reference="eRb-MF-2ki"/>
     </inferredMetricsTieBreakers>
     <resources>
         <image name="plus" catalog="system" width="128" height="113"/>

--- a/OpenMarket/OpenMarket/Views/Main.storyboard
+++ b/OpenMarket/OpenMarket/Views/Main.storyboard
@@ -73,6 +73,7 @@
                         <barButtonItem key="rightBarButtonItem" title="addProductButton" image="plus" catalog="system" id="5dz-z4-EG4">
                             <connections>
                                 <action selector="pressAddProductButton:" destination="Npz-X9-3De" id="JA4-Mx-2ks"/>
+                                <segue destination="kQk-vz-ntW" kind="show" identifier="moveProductAddIdentifier" id="7qH-ul-JML"/>
                             </connections>
                         </barButtonItem>
                     </navigationItem>
@@ -81,7 +82,7 @@
                         <outlet property="pagingLoadingUI" destination="K13-zX-OTx" id="tgc-aS-5WF"/>
                         <outlet property="productListCollectionView" destination="R7k-BP-r2b" id="wbl-gX-w3j"/>
                         <outlet property="productSegmentedControl" destination="pIz-nS-wBh" id="DWY-NM-H81"/>
-                        <segue destination="kQk-vz-ntW" kind="show" identifier="moveProductIdentifier" id="n3Z-5a-a4F"/>
+                        <segue destination="kQk-vz-ntW" kind="show" identifier="moveProductEditIdentifier" id="n3Z-5a-a4F"/>
                     </connections>
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="jpN-rM-LsM" userLabel="First Responder" customClass="UIResponder" sceneMemberID="firstResponder"/>
@@ -121,6 +122,9 @@
             <point key="canvasLocation" x="-926" y="265"/>
         </scene>
     </scenes>
+    <inferredMetricsTieBreakers>
+        <segue reference="7qH-ul-JML"/>
+    </inferredMetricsTieBreakers>
     <resources>
         <image name="plus" catalog="system" width="128" height="113"/>
         <systemColor name="systemBackgroundColor">

--- a/OpenMarket/OpenMarket/Views/ProductListView/ProductListViewController.swift
+++ b/OpenMarket/OpenMarket/Views/ProductListView/ProductListViewController.swift
@@ -6,7 +6,7 @@
 
 import UIKit
 
-class ProductListViewController: UIViewController {
+class ProductListViewController: UIViewController, ModifyDelegate {
 
     @IBOutlet weak var productListCollectionView: UICollectionView!
     @IBOutlet weak var initLoadingUI: UIActivityIndicatorView!
@@ -15,6 +15,7 @@ class ProductListViewController: UIViewController {
 
     private let productListViewModel = ProductListViewModel()
     private var products: [Product]?
+    private var productViewController: ProductViewController?
     
     override func viewDidLoad() {
         super.viewDidLoad()
@@ -24,6 +25,11 @@ class ProductListViewController: UIViewController {
         DispatchQueue.main.async {
             self.initLoadingUI.startAnimating()
         }
+    }
+
+    func modify() {
+        self.productListViewModel.productListReset()
+        self.productListViewModel.productList()
     }
 
     @IBAction func pressAddProductButton(_ sender: UIBarButtonItem) {
@@ -68,10 +74,14 @@ class ProductListViewController: UIViewController {
         self.productListCollectionView.register(GridCollectionViewCell.self, forCellWithReuseIdentifier: String(describing: GridCollectionViewCell.self))
         self.productListCollectionView.autoresizingMask = [.flexibleWidth, .flexibleHeight]
         self.productListCollectionView.collectionViewLayout = self.createListCompositionLayout()
+        self.productListCollectionView.reloadData()
     }
 
     override func prepare(for segue: UIStoryboardSegue, sender: Any?) {
         let destinationViewController = segue.destination as? ProductViewController
+        self.productViewController = destinationViewController
+        self.productViewController?.delegate = self
+
         switch segue.identifier {
         case Constant.productAddSegue:
             destinationViewController?.navigationTitle = "상품등록"

--- a/OpenMarket/OpenMarket/Views/ProductListView/ProductListViewController.swift
+++ b/OpenMarket/OpenMarket/Views/ProductListView/ProductListViewController.swift
@@ -27,7 +27,7 @@ class ProductListViewController: UIViewController {
     }
 
     @IBAction func pressAddProductButton(_ sender: UIBarButtonItem) {
-        self.performSegue(withIdentifier: Constant.productSegue, sender: self)
+        self.performSegue(withIdentifier: Constant.productAddSegue, sender: self)
     }
 
     @IBAction func changeSegmentedControl(_ sender: UISegmentedControl) {
@@ -68,6 +68,20 @@ class ProductListViewController: UIViewController {
         self.productListCollectionView.register(GridCollectionViewCell.self, forCellWithReuseIdentifier: String(describing: GridCollectionViewCell.self))
         self.productListCollectionView.autoresizingMask = [.flexibleWidth, .flexibleHeight]
         self.productListCollectionView.collectionViewLayout = self.createListCompositionLayout()
+    }
+
+    override func prepare(for segue: UIStoryboardSegue, sender: Any?) {
+        let destinationViewController = segue.destination as? ProductViewController
+        switch segue.identifier {
+        case Constant.productAddSegue:
+            destinationViewController?.navigationTitle = "상품등록"
+        case Constant.productEditSegue:
+            destinationViewController?.navigationTitle = "상품수정"
+        case .none:
+            break
+        case .some(_):
+            break
+        }
     }
 }
 
@@ -113,7 +127,7 @@ extension ProductListViewController {
 // MARK - Delegate
 extension ProductListViewController: UICollectionViewDelegate {
     func collectionView(_ collectionView: UICollectionView, didSelectItemAt indexPath: IndexPath) {
-        self.performSegue(withIdentifier: Constant.productSegue, sender: self)
+        self.performSegue(withIdentifier: Constant.productEditSegue, sender: self)
     }
 }
 

--- a/OpenMarket/OpenMarket/Views/ProductListView/ProductListViewController.swift
+++ b/OpenMarket/OpenMarket/Views/ProductListView/ProductListViewController.swift
@@ -15,7 +15,8 @@ class ProductListViewController: UIViewController, ModifyDelegate {
 
     private let productListViewModel = ProductListViewModel()
     private var products: [Product]?
-    private var productViewController: ProductViewController?
+    private var selectedProduct: Product?
+    private var moveController: ProductController?
     
     override func viewDidLoad() {
         super.viewDidLoad()
@@ -28,6 +29,7 @@ class ProductListViewController: UIViewController, ModifyDelegate {
     }
 
     func modify() {
+        print("ok")
         self.productListViewModel.productListReset()
         self.productListViewModel.productList()
     }
@@ -78,20 +80,22 @@ class ProductListViewController: UIViewController, ModifyDelegate {
     }
 
     override func prepare(for segue: UIStoryboardSegue, sender: Any?) {
-        let destinationViewController = segue.destination as? ProductViewController
-        self.productViewController = destinationViewController
-        self.productViewController?.delegate = self
-
         switch segue.identifier {
         case Constant.productAddSegue:
+            let destinationViewController = segue.destination as? ProductEditViewController
             destinationViewController?.navigationTitle = "상품등록"
-        case Constant.productEditSegue:
-            destinationViewController?.navigationTitle = "상품수정"
+            self.moveController = destinationViewController
+        case Constant.productDetailSegue:
+            let destinationViewController = segue.destination as? ProductDeatilViewController
+            destinationViewController?.product = self.selectedProduct
+            self.moveController = destinationViewController
         case .none:
             break
         case .some(_):
             break
         }
+
+        self.moveController?.delegate = self
     }
 }
 
@@ -137,7 +141,8 @@ extension ProductListViewController {
 // MARK - Delegate
 extension ProductListViewController: UICollectionViewDelegate {
     func collectionView(_ collectionView: UICollectionView, didSelectItemAt indexPath: IndexPath) {
-        self.performSegue(withIdentifier: Constant.productEditSegue, sender: self)
+        self.selectedProduct = self.products?[indexPath.row]
+        self.performSegue(withIdentifier: Constant.productDetailSegue, sender: self)
     }
 }
 

--- a/OpenMarket/OpenMarket/Views/ProductView/ProductDeatilViewController.swift
+++ b/OpenMarket/OpenMarket/Views/ProductView/ProductDeatilViewController.swift
@@ -1,0 +1,52 @@
+//
+//  ProductDeatilViewController.swift
+//  OpenMarket
+//
+//  Created by 이승주 on 2022/02/10.
+//
+
+import UIKit
+
+class ProductDeatilViewController: UIViewController, ProductController, ModifyDelegate {
+
+    private var productEditViewController: ProductEditViewController?
+    weak var delegate: ModifyDelegate?
+    var product: Product?
+    
+    private lazy var updateButton: UIBarButtonItem = {
+        let button = UIBarButtonItem(
+            title: "Update",
+            style: .plain,
+            target: self,
+            action: #selector(self.pressUpdateButton(_:))
+        )
+        return button
+    }()
+
+    override func viewDidLoad() {
+        super.viewDidLoad()
+
+        self.navigationItem.rightBarButtonItem = self.updateButton
+    }
+
+    @objc func pressUpdateButton(_ sender: UIBarButtonItem) {
+        self.performSegue(withIdentifier: Constant.productEditSegue, sender: self)
+    }
+    
+    override func prepare(for segue: UIStoryboardSegue, sender: Any?) {
+        let destinationViewController = segue.destination as? ProductEditViewController
+        destinationViewController?.product = self.product
+        self.productEditViewController = destinationViewController
+        self.productEditViewController?.delegate = self
+
+        destinationViewController?.navigationTitle = "상품수정"
+    }
+
+    func modify() {
+        DispatchQueue.main.async {
+            self.delegate?.modify()
+            self.navigationController?.popViewController(animated: true)
+        }
+    }
+
+}

--- a/OpenMarket/OpenMarket/Views/ProductView/ProductEditViewController.swift
+++ b/OpenMarket/OpenMarket/Views/ProductView/ProductEditViewController.swift
@@ -429,7 +429,7 @@ extension ProductEditViewController: UIImagePickerControllerDelegate, UINavigati
 
     func imagePickerController(_ picker: UIImagePickerController, didFinishPickingMediaWithInfo info: [UIImagePickerController.InfoKey : Any]) {
         guard self.registrationImageViewCount < 5 else {
-            print("이미지 개수 초과")
+            self.showAlert(title: "등록 가능한 이미지개수를 초과했습니다", message: nil)
             return
         }
 

--- a/OpenMarket/OpenMarket/Views/ProductView/ProductPriceSegmentValue.swift
+++ b/OpenMarket/OpenMarket/Views/ProductView/ProductPriceSegmentValue.swift
@@ -1,0 +1,11 @@
+//
+//  ProductPriceSegmentValue.swift
+//  OpenMarket
+//
+//  Created by 이승주 on 2022/02/09.
+//
+
+enum ProductPriceSegmentValue: Int {
+    case krw
+    case usd
+}

--- a/OpenMarket/OpenMarket/Views/ProductView/ProductViewController.swift
+++ b/OpenMarket/OpenMarket/Views/ProductView/ProductViewController.swift
@@ -9,6 +9,15 @@ import UIKit
 
 class ProductViewController: UIViewController {
     var navigationTitle: String?
+    private var registrationImageViewCount = 0
+    private lazy var registrationImageViewArray = [
+        registrationImageView1,
+        registrationImageView2,
+        registrationImageView3,
+        registrationImageView4,
+        registrationImageView5
+    ]
+
     private lazy var registrationImageView1: UIImageView = self.createRegistrationImageView()
     private lazy var registrationImageView2: UIImageView = self.createRegistrationImageView()
     private lazy var registrationImageView3: UIImageView = self.createRegistrationImageView()
@@ -37,7 +46,7 @@ class ProductViewController: UIViewController {
         stackView.axis = .horizontal
         stackView.distribution = .fill
         stackView.spacing = CGFloat(10)
-        stackView.alignment = .leading
+        stackView.alignment = .trailing
         return stackView
     }()
     private lazy var registrationImageScrollView: UIScrollView = {
@@ -130,7 +139,7 @@ class ProductViewController: UIViewController {
     }
 
     @objc func pressAddImageButton(_ sender: UIButton) {
-        // add image
+        self.showImagePickerControlActionSheet()
     }
 
     @objc func changeProductPriceSegmentControl(_ sender: UISegmentedControl) {
@@ -171,7 +180,10 @@ class ProductViewController: UIViewController {
         textField.keyboardType = .default
         return textField
     }
+}
 
+// MARK - bindConstraints
+extension ProductViewController {
     private func bindAllConstraints() {
         self.view.layer.cornerRadius = CGFloat(12.0)
         self.view.layer.borderColor = UIColor.gray.cgColor
@@ -237,5 +249,53 @@ class ProductViewController: UIViewController {
             self.productDescriptionTextView.topAnchor.constraint(equalTo: self.productTextFiledStackView.bottomAnchor, constant: 16),
             self.productDescriptionTextView.bottomAnchor.constraint(equalTo: self.view.layoutMarginsGuide.bottomAnchor, constant: -16)
        ])
+    }
+}
+
+// MARK - UIImagePickerController
+extension ProductViewController: UIImagePickerControllerDelegate, UINavigationControllerDelegate {
+    func showImagePickerControlActionSheet() {
+        let photoLibraryAction = UIAlertAction(title: "사진 선택하기", style: .default) { (action) in
+            self.showImagePickerController(sourceType: .photoLibrary)
+        }
+        let cameraAction = UIAlertAction(title: "사진 촬영하기", style: .default) { (action) in
+            self.showImagePickerController(sourceType: .camera)
+        }
+        let cancelAction = UIAlertAction(title: "Cancel", style: .cancel, handler: nil)
+
+        let actionSheet = UIAlertController(title: nil, message: nil, preferredStyle: .actionSheet)
+        actionSheet.addAction(photoLibraryAction)
+        actionSheet.addAction(cameraAction)
+        actionSheet.addAction(cancelAction)
+        self.present(actionSheet, animated: true, completion: nil)
+    }
+
+    func showImagePickerController(sourceType: UIImagePickerController.SourceType) {
+        let imagePickerController = UIImagePickerController()
+        imagePickerController.delegate = self
+        imagePickerController.allowsEditing = true
+        imagePickerController.sourceType = sourceType
+        self.present(imagePickerController, animated: true, completion: nil)
+    }
+
+    func imagePickerController(_ picker: UIImagePickerController, didFinishPickingMediaWithInfo info: [UIImagePickerController.InfoKey : Any]) {
+        guard self.registrationImageViewCount < 5 else {
+            print("이미지 개수 초과")
+            return
+        }
+
+        if let editedImage = info[UIImagePickerController.InfoKey.editedImage] as? UIImage {
+            self.registerImage(image: editedImage)
+        } else if let originalImage = info[UIImagePickerController.InfoKey.originalImage] as? UIImage {
+            self.registerImage(image: originalImage)
+        }
+
+        dismiss(animated: true, completion: nil)
+    }
+
+    func registerImage(image: UIImage) {
+        self.registrationImageViewArray[self.registrationImageViewCount].image = image
+        self.registrationImageViewArray[self.registrationImageViewCount].isHidden = false
+        self.registrationImageViewCount += 1
     }
 }

--- a/OpenMarket/OpenMarket/Views/ProductView/ProductViewController.swift
+++ b/OpenMarket/OpenMarket/Views/ProductView/ProductViewController.swift
@@ -144,7 +144,7 @@ class ProductViewController: UIViewController {
         self.navigationItem.title = self.navigationTitle
         self.navigationItem.leftBarButtonItem = self.cancelButton
         self.navigationItem.rightBarButtonItem = self.registerButton
-        self.setTextFieldDelegate()
+        self.setTextFieldAndTextViewDelegate()
         self.bindAllConstraints()
         self.setViewModel()
     }
@@ -170,17 +170,32 @@ class ProductViewController: UIViewController {
 
     @objc func pressRegisterButton(_ sender: UIBarButtonItem) {
         guard self.registrationImageViewCount > 0 else {
+            self.showAlert(title: "이미지를 하나 이상 등록하세요", message: nil)
             print("이미지를 하나 이상 등록하세요")
             return
         }
 
+        guard let productName = self.productNameTextField.text,
+            let productDescription = self.productDescriptionTextView.text,
+            let productOriginPriceText = self.productOriginPriceTextField.text,
+            let productOriginPrice = Double(productOriginPriceText),
+            let productDiscountedPriceText = self.productDiscountedPriceTextField.text,
+            let productDiscountedPrice = Double(productDiscountedPriceText),
+            let productStockText = self.productStockTextField.text,
+            let productStock = Int(productStockText)
+        else {
+            self.showAlert(title: "입력란을 전부 채워주세요", message: nil)
+            print("입력란을 전부 채워주세요")
+            return
+        }
+
         let postProduct = PostProduct(
-            name: self.productNameTextField.text ?? "name",
-            descriptions: self.productDescriptionTextView.text ?? "descriptions",
-            price: Double(self.productOriginPriceTextField.text ?? "0.0") ?? 0.0,
+            name: productName,
+            descriptions: productDescription,
+            price: productOriginPrice,
             currency: self.productPriceSegmentControl.selectedSegmentIndex == ProductPriceSegmentValue.krw.rawValue ? "KRW" : "USD",
-            discountedPrice: Double(self.productDiscountedPriceTextField.text ?? "0.0") ?? 0.0,
-            stock: Int(self.productStockTextField.text ?? "0") ?? 0,
+            discountedPrice: productDiscountedPrice,
+            stock: productStock,
             secret: Constant.secret
         )
 
@@ -213,11 +228,12 @@ class ProductViewController: UIViewController {
         return textField
     }
 
-    private func setTextFieldDelegate() {
+    private func setTextFieldAndTextViewDelegate() {
         self.productNameTextField.delegate = self
         self.productOriginPriceTextField.delegate = self
         self.productDiscountedPriceTextField.delegate = self
         self.productStockTextField.delegate = self
+        self.productDescriptionTextView.delegate = self
     }
 
     private func setViewModel() {
@@ -230,11 +246,35 @@ class ProductViewController: UIViewController {
             }
         }
     }
+
+    private func showAlert(title: String, message: String?) {
+        let alert = UIAlertController(title: title, message: message, preferredStyle: .alert)
+        let confirm = UIAlertAction(title: "확인", style: .default, handler: nil)
+        alert.addAction(confirm)
+        self.present(alert, animated: true, completion: nil)
+    }
 }
 
-// MARL - UITextFieldDelegate
+// MARK - UITextFieldDelegate
 extension ProductViewController: UITextFieldDelegate {
 
+}
+
+// MARK - UITextViewDelegate
+extension ProductViewController: UITextViewDelegate {
+    func textViewDidBeginEditing(_ textView: UITextView) {
+        if textView.text == Constant.productDescriptionTextViewPlaceholder {
+            textView.text = nil
+            textView.textColor = .black
+        }
+    }
+
+    func textViewDidEndEditing(_ textView: UITextView) {
+        if textView.text.isEmpty {
+            textView.text = Constant.productDescriptionTextViewPlaceholder
+            textView.textColor = .systemGray4
+        }
+    }
 }
 
 // MARK - bindConstraints

--- a/OpenMarket/OpenMarket/Views/ProductView/ProductViewController.swift
+++ b/OpenMarket/OpenMarket/Views/ProductView/ProductViewController.swift
@@ -8,22 +8,234 @@
 import UIKit
 
 class ProductViewController: UIViewController {
+    var navigationTitle: String?
+    private lazy var registrationImageView1: UIImageView = self.createRegistrationImageView()
+    private lazy var registrationImageView2: UIImageView = self.createRegistrationImageView()
+    private lazy var registrationImageView3: UIImageView = self.createRegistrationImageView()
+    private lazy var registrationImageView4: UIImageView = self.createRegistrationImageView()
+    private lazy var registrationImageView5: UIImageView = self.createRegistrationImageView()
+    private lazy var addImageButton: UIButton = {
+        let button = UIButton()
+        button.translatesAutoresizingMaskIntoConstraints = false
+        button.tintColor = .systemBlue
+        button.backgroundColor = .systemGray5
+        button.setImage(UIImage(systemName: "plus"), for: .normal)
+        button.heightAnchor.constraint(equalTo: button.widthAnchor).isActive = true
+        button.addTarget(self, action: #selector(self.pressAddImageButton(_:)), for: .touchUpInside)
+        return button
+    }()
+    private lazy var registrationImageStackView: BaseStackView = {
+        let stackView = BaseStackView(arrangedSubviews: [
+            self.registrationImageView1,
+            self.registrationImageView2,
+            self.registrationImageView3,
+            self.registrationImageView4,
+            self.registrationImageView5,
+            self.addImageButton
+        ])
+        stackView.translatesAutoresizingMaskIntoConstraints = false
+        stackView.axis = .horizontal
+        stackView.distribution = .fill
+        stackView.spacing = CGFloat(10)
+        stackView.alignment = .leading
+        return stackView
+    }()
+    private lazy var registrationImageScrollView: UIScrollView = {
+        let scrollView = UIScrollView()
+        scrollView.translatesAutoresizingMaskIntoConstraints = false
+        scrollView.showsVerticalScrollIndicator = false
+        scrollView.showsHorizontalScrollIndicator = false
+        scrollView.backgroundColor = .clear
+        return scrollView
+    }()
+
+    private lazy var productNameTextField: UITextField = self.createProductTextField(placeholer: Constant.productNameTextFieldPlaceholder)
+    private lazy var productOriginPriceTextField: UITextField = self.createProductTextField(placeholer: Constant.productOriginPriceTextFieldPlaceholder)
+    private lazy var productPriceSegmentControl: UISegmentedControl = {
+        let segmentControl: UISegmentedControl = UISegmentedControl(items: [NSString("KRW"), NSString("USD")])
+        segmentControl.translatesAutoresizingMaskIntoConstraints = false
+        segmentControl.addTarget(self, action: #selector(self.changeProductPriceSegmentControl(_:)), for: .valueChanged)
+        segmentControl.selectedSegmentIndex = 0
+        return segmentControl
+    }()
+    private lazy var productOriginPriceStackView: BaseStackView = {
+        let stackView = BaseStackView(arrangedSubviews: [
+            self.productOriginPriceTextField,
+            self.productPriceSegmentControl
+        ])
+        stackView.translatesAutoresizingMaskIntoConstraints = false
+        stackView.axis = .horizontal
+        stackView.distribution = .fill
+        stackView.spacing = CGFloat(10)
+        stackView.alignment = .center
+        return stackView
+    }()
+    private lazy var productDiscountedPriceTextField: UITextField = self.createProductTextField(placeholer: Constant.productDiscountedPriceTextFieldPlaceholder)
+    private lazy var productStockTextField: UITextField = self.createProductTextField(placeholer: Constant.productStockTextFieldPlaceholder)
+    private lazy var productTextFiledStackView: BaseStackView = {
+        let stackView = BaseStackView(arrangedSubviews: [
+            self.productNameTextField,
+            self.productOriginPriceStackView,
+            self.productDiscountedPriceTextField,
+            self.productStockTextField
+        ])
+        stackView.translatesAutoresizingMaskIntoConstraints = false
+        stackView.axis = .vertical
+        stackView.distribution = .fill
+        stackView.spacing = CGFloat(10)
+        stackView.alignment = .leading
+        return stackView
+    }()
+
+    private let productDescriptionTextView: UITextView = {
+        let textView = UITextView()
+        textView.translatesAutoresizingMaskIntoConstraints = false
+        textView.font = UIFont.preferredFont(forTextStyle: .body)
+        textView.text = Constant.productDescriptionTextViewPlaceholder
+        textView.textColor = .systemGray4
+        textView.textAlignment = .left
+        textView.backgroundColor = .clear
+        textView.keyboardType = .default
+        return textView
+    }()
+
+    private lazy var cancelButton: UIBarButtonItem = {
+        let button = UIBarButtonItem(
+            title: "Cancel",
+            style: .plain,
+            target: self,
+            action: #selector(self.pressCancelButton(_:))
+        )
+        return button
+    }()
+
+    private lazy var registerButton: UIBarButtonItem = {
+        let button = UIBarButtonItem(
+            title: "Done",
+            style: .plain,
+            target: self,
+            action: #selector(self.pressRegisterButton(_:))
+        )
+        return button
+    }()
 
     override func viewDidLoad() {
         super.viewDidLoad()
 
-        // Do any additional setup after loading the view.
+        self.navigationItem.backButtonDisplayMode = .minimal
+        self.navigationItem.title = self.navigationTitle
+        self.navigationItem.leftBarButtonItem = self.cancelButton
+        self.navigationItem.rightBarButtonItem = self.registerButton
+        self.bindAllConstraints()
     }
-    
 
-    /*
-    // MARK: - Navigation
-
-    // In a storyboard-based application, you will often want to do a little preparation before navigation
-    override func prepare(for segue: UIStoryboardSegue, sender: Any?) {
-        // Get the new view controller using segue.destination.
-        // Pass the selected object to the new view controller.
+    @objc func pressAddImageButton(_ sender: UIButton) {
+        // add image
     }
-    */
 
+    @objc func changeProductPriceSegmentControl(_ sender: UISegmentedControl) {
+        switch sender.selectedSegmentIndex {
+        case ProductPriceSegmentValue.krw.rawValue:
+            print("krw")
+        case ProductPriceSegmentValue.usd.rawValue:
+            print("usd")
+        default:
+            break
+        }
+    }
+
+    @objc func pressCancelButton(_ sender: UIBarButtonItem) {
+        self.navigationController?.popViewController(animated: true)
+    }
+
+    @objc func pressRegisterButton(_ sender: UIBarButtonItem) {
+        // add or update product
+        print(#function)
+    }
+
+    private func createRegistrationImageView() -> UIImageView {
+        let imageView = UIImageView()
+        imageView.translatesAutoresizingMaskIntoConstraints = false
+        imageView.contentMode = .scaleAspectFit
+        imageView.heightAnchor.constraint(equalTo: imageView.widthAnchor).isActive = true
+        imageView.image = UIImage(systemName: "pencil")
+        imageView.isHidden = true
+        return imageView
+    }
+
+    private func createProductTextField(placeholer: String) -> UITextField {
+        let textField = UITextField()
+        textField.translatesAutoresizingMaskIntoConstraints = false
+        textField.placeholder = placeholer
+        textField.borderStyle = .roundedRect
+        textField.keyboardType = .default
+        return textField
+    }
+
+    private func bindAllConstraints() {
+        self.view.layer.cornerRadius = CGFloat(12.0)
+        self.view.layer.borderColor = UIColor.gray.cgColor
+        self.view.layer.borderWidth = CGFloat(1.0)
+
+        self.bindRegistrationImageStackViewConstraints()
+        self.bindProductTextFiledStackViewConstraints()
+        self.bindProductDescriptionTextViewConstraints()
+    }
+
+    private func bindRegistrationImageStackViewConstraints() {
+        self.view.addSubview(self.registrationImageScrollView)
+        self.registrationImageScrollView.addSubview(self.registrationImageStackView)
+        let contentLayoutGuide = self.registrationImageScrollView.contentLayoutGuide
+
+        NSLayoutConstraint.activate([
+            self.registrationImageView1.widthAnchor.constraint(equalTo: self.view.safeAreaLayoutGuide.widthAnchor, multiplier: 0.3),
+            self.registrationImageView2.widthAnchor.constraint(equalTo: self.view.safeAreaLayoutGuide.widthAnchor, multiplier: 0.3),
+            self.registrationImageView3.widthAnchor.constraint(equalTo: self.view.safeAreaLayoutGuide.widthAnchor, multiplier: 0.3),
+            self.registrationImageView4.widthAnchor.constraint(equalTo: self.view.safeAreaLayoutGuide.widthAnchor, multiplier: 0.3),
+            self.registrationImageView5.widthAnchor.constraint(equalTo: self.view.safeAreaLayoutGuide.widthAnchor, multiplier: 0.3),
+            self.addImageButton.widthAnchor.constraint(equalTo: self.view.safeAreaLayoutGuide.widthAnchor, multiplier: 0.3),
+
+            self.registrationImageScrollView.leadingAnchor.constraint(equalTo: self.view.safeAreaLayoutGuide.leadingAnchor, constant: 16),
+            self.registrationImageScrollView.trailingAnchor.constraint(lessThanOrEqualTo: self.view.safeAreaLayoutGuide.trailingAnchor, constant: -16),
+            self.registrationImageScrollView.topAnchor.constraint(equalTo: self.view.safeAreaLayoutGuide.topAnchor, constant: 16),
+            self.registrationImageScrollView.widthAnchor.constraint(equalTo: self.view.widthAnchor, constant: -32),
+
+            self.registrationImageStackView.leadingAnchor.constraint(equalTo: contentLayoutGuide.leadingAnchor),
+            self.registrationImageStackView.trailingAnchor.constraint(equalTo: contentLayoutGuide.trailingAnchor),
+            self.registrationImageStackView.topAnchor.constraint(equalTo: contentLayoutGuide.topAnchor),
+            self.registrationImageStackView.bottomAnchor.constraint(equalTo: contentLayoutGuide.bottomAnchor),
+
+            self.registrationImageStackView.heightAnchor.constraint(equalTo: self.registrationImageScrollView.heightAnchor)
+       ])
+    }
+
+    private func bindProductTextFiledStackViewConstraints() {
+        self.view.addSubview(self.productTextFiledStackView)
+        NSLayoutConstraint.activate([
+            self.productTextFiledStackView.leadingAnchor.constraint(equalTo: self.view.safeAreaLayoutGuide.leadingAnchor, constant: 16),
+            self.productTextFiledStackView.trailingAnchor.constraint(equalTo: self.view.safeAreaLayoutGuide.trailingAnchor, constant: -16),
+            self.productTextFiledStackView.topAnchor.constraint(equalTo: self.registrationImageStackView.bottomAnchor, constant: 16),
+            self.productTextFiledStackView.heightAnchor.constraint(equalTo: self.view.heightAnchor, multiplier: 0.2),
+
+            self.productNameTextField.leadingAnchor.constraint(equalTo: self.productTextFiledStackView.leadingAnchor),
+            self.productNameTextField.trailingAnchor.constraint(equalTo: self.productTextFiledStackView.trailingAnchor),
+            self.productOriginPriceTextField.leadingAnchor.constraint(equalTo: self.productTextFiledStackView.leadingAnchor),
+            self.productOriginPriceTextField.widthAnchor.constraint(equalTo: self.productTextFiledStackView.widthAnchor, multiplier: 0.65),
+            self.productPriceSegmentControl.trailingAnchor.constraint(equalTo: self.productTextFiledStackView.trailingAnchor),
+            self.productDiscountedPriceTextField.leadingAnchor.constraint(equalTo: self.productTextFiledStackView.leadingAnchor),
+            self.productDiscountedPriceTextField.trailingAnchor.constraint(equalTo: self.productTextFiledStackView.trailingAnchor),
+            self.productStockTextField.leadingAnchor.constraint(equalTo: self.productTextFiledStackView.leadingAnchor),
+            self.productStockTextField.trailingAnchor.constraint(equalTo: self.productTextFiledStackView.trailingAnchor)
+       ])
+    }
+
+    private func bindProductDescriptionTextViewConstraints() {
+        self.view.addSubview(self.productDescriptionTextView)
+        NSLayoutConstraint.activate([
+            self.productDescriptionTextView.leadingAnchor.constraint(equalTo: self.productTextFiledStackView.leadingAnchor),
+            self.productDescriptionTextView.trailingAnchor.constraint(equalTo: self.productTextFiledStackView.trailingAnchor),
+            self.productDescriptionTextView.topAnchor.constraint(equalTo: self.productTextFiledStackView.bottomAnchor, constant: 16),
+            self.productDescriptionTextView.bottomAnchor.constraint(equalTo: self.view.layoutMarginsGuide.bottomAnchor, constant: -16)
+       ])
+    }
 }

--- a/OpenMarket/OpenMarketTests/OpenMarketTests.swift
+++ b/OpenMarket/OpenMarketTests/OpenMarketTests.swift
@@ -10,14 +10,14 @@ import XCTest
 
 class OpenMarketTests: XCTestCase {
 
-    let projectListRepository = RepositoryInjection.injectProductListRepository()
-    let projectRepository = RepositoryInjection.injectProductRepository()
+    let productListRepository = RepositoryInjection.injectProductListRepository()
+    let productRepository = RepositoryInjection.injectProductRepository()
 
     func test_상품리스트_받아오기_성공() {
         let pageNumber = 1
         let itemPerPage = 10
 
-        self.projectListRepository.productList(pageNumber: pageNumber, itemsPerPage: itemPerPage) { result in
+        self.productListRepository.productList(pageNumber: pageNumber, itemsPerPage: itemPerPage) { [weak self] result in
             switch result {
             case .success(let productList):
                 var result = true
@@ -35,7 +35,7 @@ class OpenMarketTests: XCTestCase {
     func test_상품_받아오기_성공() {
         let productId = 522
 
-        self.projectRepository.product(productId: productId) { result in
+        self.productRepository.product(productId: productId) { [weak self] result in
             switch result {
             case .success(let product):
                 var result = true
@@ -45,6 +45,34 @@ class OpenMarketTests: XCTestCase {
                 XCTAssertEqual(result, true)
             case .failure(let error):
                 XCTFail("상품리스트 받아오기: 네트워크에러")
+            }
+        }
+        sleep(3)
+    }
+
+    func test_상품등록_성공() {
+        let postProduct = PostProduct(
+            name: "좋은 상품",
+            descriptions: "넘 좋아요",
+            price: 100,
+            currency: "KRW",
+            discountedPrice: 90,
+            stock: 10,
+            secret: Constant.secret
+        )
+        let image = UIImage(systemName: "pencil")
+        let images = [image, image]
+
+        self.productRepository.addProduct(postProduct: postProduct, productImages: images) { [weak self] result in
+            switch result {
+            case .success(let product):
+                var result = true
+                if product == nil {
+                    result = false
+                }
+                XCTAssertEqual(result, true)
+            case .failure(let error):
+                XCTFail("상품등록: 네트워크에러")
             }
         }
         sleep(3)

--- a/OpenMarket/OpenMarketTests/OpenMarketTests.swift
+++ b/OpenMarket/OpenMarketTests/OpenMarketTests.swift
@@ -78,6 +78,47 @@ class OpenMarketTests: XCTestCase {
         sleep(3)
     }
 
+    func test_상품수정_성공() {
+        let postProduct = PostProduct(
+            name: "좋은 상품",
+            descriptions: "넘 좋아요",
+            price: 100,
+            currency: "KRW",
+            discountedPrice: 90,
+            stock: 10,
+            secret: Constant.secret
+        )
+        let image = UIImage(systemName: "pencil")
+        let images = [image, image]
+
+        self.productRepository.addProduct(postProduct: postProduct, productImages: images) { [weak self] result in
+            switch result {
+            case .success(let product):
+                guard let product = product else { return }
+
+                let id = product.id
+                self?.productRepository.updateProduct(
+                    productId: id,
+                    postProduct: postProduct,
+                    productImages: images, completion: { [weak self] result in
+                        switch result {
+                        case .success(let product):
+                            var result = true
+                            if product == nil {
+                                result = false
+                            }
+                            XCTAssertEqual(result, true)
+                        case .failure(let error):
+                            XCTFail("상품수정: 네트워크에러")
+                        }
+                    })
+            case .failure(let error):
+                XCTFail("상품등록: 네트워크에러")
+            }
+        }
+        sleep(3)
+    }
+
     override func setUpWithError() throws {
         try super.setUpWithError()
     }


### PR DESCRIPTION
# STEP3

@wonhee009
안녕하세요 라자냐! 조엘입니다 :)
오픈마켓 STEP3 PR 요청드립니다!
</br>

# 구현한 것
코드를 이용해서 UI를 구현
 - 상품 등록/수정 화면
 - ProductEditViewController는 상품 등록/수정 화면에 대한 뷰
 - ProductDeatilViewController는 상품 상세화면에 대한 뷰
</br>

상품 등록 & 수정 구현
 - post & patch를 통해서 상품을 등록
 - 상품 등록 & 수정 시 delegate 패턴을 이용하여 상품 리스트 화면에서 리스트를 다시 불러오도록 구현
</br>

# 궁금한 점
1. ProductListViewController에서 delegate를 prepare(98번째 라인)에서 하도록 구현하였습니다. 네비게이션 컨트롤러에서 스택에 쌓는 뷰컨트롤러에 대한 delegate를 이런 방식을 사용해서 하는 방법에 대해서 라자냐는 어떻게 생각하시는지 궁금하고, 혹시 더 좋은 방법이 있다면 알고 싶습니다!

2. 상품 수정 시 네비게이션 컨트롤러가 pop이 2번 되는 부자연스러움
ProductListViewController -> ProductDeatilViewController ->  ProductEditViewController로 이동하여 상품 수정에서 수정을 하면 navigationController?.popViewController가 2번 호출돼서 굉장히 UI의 움직임이 부자연스러운데, 어떻게 개선할 수 있을지 궁금합니다!

3. ProductEditViewController의 229라인은 174번 라인과 다르게 왜 메인 스레드에서 실행하지 않으면 오류가 나는데, escaping closure에서 발생하는 특별한 상황인지 잘 모르겠습니다. 혹시 라자냐가 이에 대해 알려주시면 감사하겠습니다!

4. ProductEditViewController에서 UI를 코드로 구현하였는데, 코드가 많이 길어서 가독성이 좋지 않은 것 같습니다. 그래서 혹시 UI 코드 위치를 좀 수정하면 나아질까 해서, UI를 코드로 구현할 때 뷰컨트롤러에서 적합한 위치가 있을까 싶어서 이에 대해 여쭤보고 싶습니다!
</br>

5. 추가로 NetworkManager의 80라인 부터 구현한 코드가 괜찮은 방식인지 궁금합니다! for문을 돌리기 싫어서 고차함수를 사용하였는데, 사실 map의 블락의 코드가 map 역할을 하고 있지는 않아서요! 혹시 고차함수를 사용하여 이를 구현할 때, 이보다 좋은 방법이 있으면 알고 싶습니다!
</br>

# 마무리
STEP2가 머지되고 시간이 너무 촉박해서 클린하게 구현하지 못한것 같습니다 ㅜ 또한.. STEP2에서 미해결 과제가 되어버린 list->grid 변경 시 레이아웃이 밀리는 현상 & grid에서 빠르게 스크롤 시 레이아웃이 깨지는 현상은 아직 해결하지 못했네요...

많이 아쉽지만 그래도 urlsession을 통해서 post와 patch를 하는 과정을 이해하는 것에 많은 도움이 된 것 같습니다! 항상 꼼꼼한 리뷰에 감사드립니다 :)
</br>
